### PR TITLE
Fix/etc before launch

### DIFF
--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -56,7 +56,7 @@ export default function ChatPage({ params }: { params: { id: string } }) {
 			<div className="py-4 xl:px-24 lg:px-18 md:px-14 sm:px-3 w-full">
 				<div className="flex flex-col">
 					<div className="flex flex-row pb-4 mb-4 md:relative md:left-[-50px] md:top-[20px] justify-center md:justify-normal">
-						<h1 className="text-4xl px-4 font-semibold">SAGE</h1>
+						<h1 className="fixed md:relative text-4xl px-4 font-semibold">SAGE</h1>
 						<InfoToolTip />
 					</div>
 					<ChatInterface />

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -53,7 +53,7 @@ export default function ChatPage({ params }: { params: { id: string } }) {
 	return (
 		<div className="m-4 flex">
 			<Nav />
-			<div className="py-4 xl:px-24 lg:px-18 md:px-14 sm:px-3 w-full">
+			<div className="sm:py-4 xl:px-24 lg:px-18 md:px-14 sm:px-3 w-full">
 				<div className="flex flex-col">
 					<div className="flex flex-row pb-4 mb-4 md:relative md:left-[-50px] md:top-[20px] justify-center md:justify-normal">
 						<h1 className="fixed md:relative text-4xl px-4 font-semibold">SAGE</h1>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,7 @@
 
 body {
 	font-family: Arial, Helvetica, sans-serif;
+	height: 98dvh;
 }
 
 @layer utilities {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Plus_Jakarta_Sans } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "sonner";
 import { TouchProvider } from "@/components/ui/TouchProvider";
+import Head from "next/head";
 
 const plusJakartaSans = Plus_Jakarta_Sans({
 	subsets: ["latin"],
@@ -37,6 +38,10 @@ export default function RootLayout({
 }>) {
 	return (
 		<html lang="en">
+			<Head>
+			<meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content" />
+
+			</Head>
 			<body
 				className={`${plusJakartaSans.className} ${geistSans.variable} ${geistMono.variable} antialiased`}
 			>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,7 +42,7 @@ export default function Home() {
 	return (
 		<div className="m-4 flex">
 			<Nav />
-			<div className="py-4 xl:px-24 lg:px-18 md:px-14 sm:px-3 w-full">
+			<div className="sm:py-4 xl:px-24 lg:px-18 md:px-14 sm:px-3 w-full">
 				<div className="flex flex-col gap-8">
 					<div className="flex flex-row pb-4 md:relative md:left-[-50px] md:top-[20px] justify-center md:justify-normal">
 						<h1 className="fixed md:relative text-4xl px-4 font-semibold">SAGE</h1>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,7 +45,7 @@ export default function Home() {
 			<div className="py-4 xl:px-24 lg:px-18 md:px-14 sm:px-3 w-full">
 				<div className="flex flex-col gap-8">
 					<div className="flex flex-row pb-4 md:relative md:left-[-50px] md:top-[20px] justify-center md:justify-normal">
-						<h1 className="text-4xl px-4 font-semibold">SAGE</h1>
+						<h1 className="fixed md:relative text-4xl px-4 font-semibold">SAGE</h1>
 						<InfoToolTip />
 					</div>
 					<ChatInterface />

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Button } from "./ui/button";
-import { Mic, Send } from "lucide-react";
+import { Mic, SendHorizonal } from "lucide-react";
 import {
 	AlertDialog,
 	AlertDialogCancel,
@@ -155,7 +155,7 @@ export default function ChatInput({
 				className={`rounded-3xl px-3 bg-sage-primary`}
 				variant="ghost"
 			>
-				<Send className="md:hidden text-white" />
+				<SendHorizonal className="md:hidden text-white" />
 				<span className="hidden md:block text-white">Send</span>
 			</Button>
 			</div>

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -220,7 +220,7 @@ export default function ChatInterface() {
 	};
 
 	return (
-		<div className="flex flex-col h-[calc(100vh-10rem)] supports-[dvh]:h-[calc(100dvh-10rem)] w-full items-center">
+		<div className="flex flex-col h-[calc(100dvh-5rem)] sm:h-[calc(100vh-10rem)] supports-[dvh]:h-[calc(100dvh-10rem)] w-full items-center">
 			{messages && messages.length > 0 && (
 				<div className="xl:px-20 mt-4 flex-grow overflow-auto w-full">
 					<ChatMessages messages={messages} isStreaming={isStreaming} />
@@ -281,14 +281,14 @@ export default function ChatInterface() {
 							</div>
 						</div>
 					</div> */}
-					<h1 className="text-4xl font-bold mb-10 mt-5 md:mt-20 text-center w-72 md:w-1/2 flex-1 text-transparent bg-clip-text bg-light-teal-gradient dark:bg-dark-teal-gradient">
+					<h1 className="text-3xl md:text-4xl font-bold mt-20 md:mb-10 text-center w-72 md:w-1/2 flex-1 text-transparent bg-clip-text bg-light-teal-gradient dark:bg-dark-teal-gradient">
 						What would you like to know more about?
 					</h1>
 					<Image
 					src={logo}
 					alt="Sage Wizard Logo"
 					width={150}
-					className="mt-10 pointer-events-none select-none"
+					className="mt-10 w-24 pointer-events-none select-none"
 					/>
 					<div className="overflow-auto flex justify-end lg:items-center flex-col h-full w-full">
 						<div className="flex flex-col overflow-auto mb-8">

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -220,9 +220,9 @@ export default function ChatInterface() {
 	};
 
 	return (
-		<div className="flex flex-col h-[calc(100vh-10rem)] w-full items-center">
+		<div className="flex flex-col h-[calc(100vh-10rem)] supports-[dvh]:h-[calc(100dvh-10rem)] w-full items-center">
 			{messages && messages.length > 0 && (
-				<div className="xl:px-20 flex-grow overflow-auto w-full">
+				<div className="xl:px-20 mt-4 flex-grow overflow-auto w-full">
 					<ChatMessages messages={messages} isStreaming={isStreaming} />
 				</div>
 			)}

--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -83,7 +83,7 @@ export default function ChatMessages({
 
 	return (
 		<div
-			className="overflow-y-auto h-full w-full mt-auto justify-start flex flex-col margin-top: auto"
+			className="overflow-y-auto h-full w-full flex flex-col margin-top: auto"
 			id="chat-messages"
 			ref={scrollRef}
 			style={{
@@ -95,7 +95,7 @@ export default function ChatMessages({
 			{activeConversation?.messages.map((message, index) => (
 				<div
 					key={index}
-					className={`flex ${message.isUser ? "justify-end" : "justify-start"
+					className={`first:mt-auto flex ${message.isUser ? "justify-end" : "justify-start"
 						} p-2`}
 				>
 					<div

--- a/src/components/InfoTooltip.tsx
+++ b/src/components/InfoTooltip.tsx
@@ -12,7 +12,7 @@ const CustomTooltip = () => {
 		<TouchProvider>
 			<TooltipProvider delayDuration={250}>
 				<HybridTooltip>
-					<HybridTooltipTrigger className="fixed right-0 py-2 px-4 md:relative md:right-[unset] md:py-0 md:px-0">
+					<HybridTooltipTrigger className="fixed right-4 py-2 px-4 md:relative md:right-[unset] md:py-0 md:px-0">
 						<Info />
 					</HybridTooltipTrigger>
 					<HybridTooltipContent

--- a/src/components/InfoTooltip.tsx
+++ b/src/components/InfoTooltip.tsx
@@ -12,7 +12,7 @@ const CustomTooltip = () => {
 		<TouchProvider>
 			<TooltipProvider delayDuration={250}>
 				<HybridTooltip>
-					<HybridTooltipTrigger className="absolute right-0 py-2 px-4 md:relative md:right-[unset] md:py-0 md:px-0">
+					<HybridTooltipTrigger className="fixed right-0 py-2 px-4 md:relative md:right-[unset] md:py-0 md:px-0">
 						<Info />
 					</HybridTooltipTrigger>
 					<HybridTooltipContent

--- a/src/components/Navigation/Nav.tsx
+++ b/src/components/Navigation/Nav.tsx
@@ -127,7 +127,7 @@ export default function Nav() {
 			<div className="md:hidden">
 				<Sheet onOpenChange={() => setTimeout(() => document.body.style.pointerEvents = "", 500)}>
 					<SheetTrigger className="fixed mt-1" asChild>
-						<Button variant="ghost" className="hover:bg-gray-300/40" >
+						<Button variant="ghost" className="hover:bg-gray-300/40 -top-4 sm:top-0" >
 							<Menu />
 						</Button>
 					</SheetTrigger>

--- a/src/components/chat_options/RenameChat.tsx
+++ b/src/components/chat_options/RenameChat.tsx
@@ -1,6 +1,5 @@
-import { AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "../ui/alert-dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "../ui/form";
-import { Pencil, X } from "lucide-react";
+import { Pencil } from "lucide-react";
 import { Button } from "../ui/button";
 import { useForm } from "react-hook-form";
 import { Input } from "../ui/input";
@@ -9,6 +8,7 @@ import { z } from "zod"
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
 import { toast } from "sonner";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "../ui/dialog";
 
 const renameForm = z.object({
 	name: z.string()
@@ -47,23 +47,17 @@ export default function RenameChat({
 	}
 
 	return (
-		<AlertDialog open={open} onOpenChange={setOpen}>
-			<AlertDialogTrigger className="flex gap-10 relative px-2 py-1.5 transition-all  hover:bg-gray-300/50 text-sm items-center rounded-sm w-full">
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger className="flex gap-10 relative px-2 py-1.5 transition-all  hover:bg-gray-300/50 text-sm items-center rounded-sm w-full">
 				<p>Rename</p>
 				<Pencil className="w-5 h-5 ml-auto" />
-			</AlertDialogTrigger>
-			<AlertDialogContent>
-				<AlertDialogHeader>
-					<AlertDialogCancel asChild>
-						<Button variant="ghost" className="absolute top-2 right-2 border-0">
-							<X className="opacity-70 w-4 h-4" />
-							<span className="sr-only">Close</span>
-						</Button>
-					</AlertDialogCancel>
-					<AlertDialogTitle>
+			</DialogTrigger>
+			<DialogContent className="overflow-y-scroll max-h-dvh">
+				<DialogHeader>
+					<DialogTitle>
 						Rename <span className="text-">{`"${convo.title}"`}</span>
-					</AlertDialogTitle>
-					<AlertDialogDescription className="hidden" />
+					</DialogTitle>
+					<DialogDescription className="hidden" />
 					<Form {...form}>
 						<form onSubmit={form.handleSubmit((data) => {
 							onSubmit(data, convo)
@@ -75,7 +69,7 @@ export default function RenameChat({
 									<FormItem>
 										<FormLabel className="hidden">New Name</FormLabel>
 										<FormControl>
-											<Input placeholder={convo.title} type="text" autoComplete="off" {...field} />
+											<Input placeholder={convo.title} type="text" autoComplete="off" {...field} className="text-base" />
 										</FormControl>
 										<FormMessage />
 									</FormItem>
@@ -83,8 +77,8 @@ export default function RenameChat({
 							<Button type="submit" className="mr-2 rounded-xl">Submit</Button>
 						</form>
 					</Form>
-				</AlertDialogHeader>
-			</AlertDialogContent>
-		</AlertDialog>
+				</DialogHeader>
+			</DialogContent>
+		</Dialog>
 	)
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { cn } from "@/lib/utils"
+import { Cross2Icon } from "@radix-ui/react-icons"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <Cross2Icon className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}


### PR DESCRIPTION
This pr fixes:
- Mobile: having to scroll to see message input
- Mobile: SAGE header and Info tooltip not in fixed positions 
- Mobile: virtual keyboard misaligning components and not realigning them when it closes
- Mobile: Example message bubbles being squashed and hidden somehow when height of the browser is compressed a little
- Mobile: alignment of the info tooltip to match the nav Menu icon
- Mobile: safari default zooms in on text inputs (RenameChat form) when the font is less than 16 px, leading to more problems like the user not being able to zoom out
- Some style changes like making the body `98dvh` (not 100 because it causes overflow from a component that has a margin somewhere)